### PR TITLE
Update cpython dependency to version 3.12.7

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "1.1.0"
+version: "1.0.2-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "1.0.1"
+version: "1.1.0"

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,7 +94,7 @@ class UvulaConan(ConanFile):
         self.requires("range-v3/0.12.0")
         self.requires("clipper/6.4.2@ultimaker/stable")
         if self.options.get_safe("with_python_bindings", False):
-            self.requires("cpython/3.12.2")
+            self.requires("cpython/3.12.7")
             self.requires("pybind11/2.11.1")
         if self.options.get_safe("with_cli", False):
             self.requires("assimp/5.4.3")


### PR DESCRIPTION

This pull request updates the version of the `cpython` dependency used when building with Python bindings. This ensures the project uses the latest patch release for improved stability and security.

Dependency version update:

* Updated `cpython` from version `3.12.2` to `3.12.7` in the `requirements` method of `conanfile.py` for builds with Python bindings.

CURA-12814