### PR TITLE
CURA-12913 UV unwrapping issues

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "1.0.0"
+version: "1.0.1"

--- a/src/unwrap.cpp
+++ b/src/unwrap.cpp
@@ -63,7 +63,7 @@ std::vector<Vector3F> calculateProjectionNormals(const std::vector<FaceData>& fa
     };
 
     // The unprocessed_faces is a sub-range of the faces list, that contains all the faces that have not been assigned to a group yet.
-    FaceDataRange unprocessed_faces = { .begin = faces_to_process.begin(), .end = faces_to_process.end() };
+    FaceDataRange unprocessed_faces = { .begin = std::next(faces_to_process.begin()), .end = faces_to_process.end() };
 
     while (true)
     {
@@ -85,7 +85,7 @@ std::vector<Vector3F> calculateProjectionNormals(const std::vector<FaceData>& fa
         Vector3F summed_normals = std::accumulate(
             current_faces_group.begin,
             current_faces_group.end,
-            Vector3F(),
+            *project_normal,
             [](const Vector3F& normal, const FaceData* face_data)
             {
                 return normal + face_data->normal;


### PR DESCRIPTION
Groups normals were not properly generated when encountering a group that contained a single triangle. Now at each iteration of the loop, we don't re-test the already selected face but still take its normal into the accumulation of normals, so that if there only 1 face, the result is the normal of the single face instead of a null vector.

CURA-12913
Comes with https://github.com/Ultimaker/Uranium/pull/1025